### PR TITLE
error in file name and add command to start

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ fi
 if [ "$READY" = "yes" ]; then
     systemctl start cs-custom-bouncer.service
 else
-    echo "service not started. You need to get an API key and configure it in ${CONFIG_DIR}cs-firewall-bouncer.yaml"
+    echo "service not started. You need to get an API key and configure it in ${CONFIG_DIR}cs-custom-bouncer.yaml and then run systemctl start cs-custom-bouncer.service"
 fi
 
 echo "cs-custom-bouncer service has been installed!"


### PR DESCRIPTION
The filename is `cs-custom-bouncer.yaml` and not `cs-firewall-bouncer.yaml` . 

And I add the command to start the service manually ( can be discussed, but for me, "not a linux expert about how to start the service" it can help ... And yes it's already written in the readme, but the filename too, not sure about what to do )