### PR TITLE
Fix naming inconsistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ BUILD_VERSION?="$(shell git describe --tags `git rev-list --tags --max-count=1`)
 BUILD_GOVERSION="$(shell go version | cut -d " " -f3 | sed -r 's/[go]+//g')"
 BUILD_TIMESTAMP=$(shell date +%F"_"%T)
 BUILD_TAG="$(shell git rev-parse HEAD)"
-export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec-custom-bouncer/pkg/version.Version=$(BUILD_VERSION) \
--X github.com/crowdsecurity/crowdsec-custom-bouncer/pkg/version.BuildDate=$(BUILD_TIMESTAMP) \
--X github.com/crowdsecurity/crowdsec-custom-bouncer/pkg/version.Tag=$(BUILD_TAG) \
--X github.com/crowdsecurity/crowdsec-custom-bouncer/pkg/version.GoVersion=$(BUILD_GOVERSION)"
+export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/cs-custom-bouncer/pkg/version.Version=$(BUILD_VERSION) \
+-X github.com/crowdsecurity/cs-custom-bouncer/pkg/version.BuildDate=$(BUILD_TIMESTAMP) \
+-X github.com/crowdsecurity/cs-custom-bouncer/pkg/version.Tag=$(BUILD_TAG) \
+-X github.com/crowdsecurity/cs-custom-bouncer/pkg/version.GoVersion=$(BUILD_GOVERSION)"
 
 RELDIR = "crowdsec-custom-bouncer-${BUILD_VERSION}"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crowdsecurity/crowdsec-custom-bouncer
+module github.com/crowdsecurity/cs-custom-bouncer
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 
-	"github.com/crowdsecurity/crowdsec-custom-bouncer/pkg/version"
+	"github.com/crowdsecurity/cs-custom-bouncer/pkg/version"
 	csbouncer "github.com/crowdsecurity/go-cs-bouncer"
 	"gopkg.in/tomb.v2"
 )


### PR DESCRIPTION
While distribution packages are probably going to use an explicit name like crowdsec-custom-bouncer, it makes sense to have the Go import path match the location of the Git repository (as that's already done for cs-firewall-bouncer).


Note: This is definitely not a blocker packaging-wise (I already have a local patch anyway), I just have to make sure the `Go-Import-Path` declared in `debian/control` matches the declared module name to ensure the build is fine. I could do the opposite, and do `cs-` → `crowdsec-` in the `Go-Import-Path`, whatever works for you is fine with me.