### PR TITLE
fix: Feedviastdin total retires

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,7 +108,7 @@ func feedViaStdin(ctx context.Context, custom *custom.CustomBouncer, config *cfg
 			log.Errorf("Binary exited: %s", err)
 		}
 	} else {
-		// i needs to start at 0 so we at least try once to start the process if config.TotalRetires is not set
+		// i needs to start at 0 so we at least try once to start the process if config.TotalRetries is not set
 		for i := 0; i <= config.TotalRetries; i++ {
 			err = f()
 			log.Errorf("Binary exited (retry %d/%d): %s", i, config.TotalRetries, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,7 +108,8 @@ func feedViaStdin(ctx context.Context, custom *custom.CustomBouncer, config *cfg
 			log.Errorf("Binary exited: %s", err)
 		}
 	} else {
-		for i := 1; i <= config.TotalRetries; i++ {
+		// i needs to start at 0 so we at least try once to start the process if config.TotalRetires is not set
+		for i := 0; i <= config.TotalRetries; i++ {
 			err = f()
 			log.Errorf("Binary exited (retry %d/%d): %s", i, config.TotalRetries, err)
 		}


### PR DESCRIPTION
If total retries is not set then it will never execute the binary because we start the for loop at 1, changing to 0 means it at least tries to execute the binary once before attempting the total retries.